### PR TITLE
Observe build preference for reference files

### DIFF
--- a/Brotli.NET/build/Brotli.NET.targets
+++ b/Brotli.NET/build/Brotli.NET.targets
@@ -7,7 +7,7 @@
       <Link>%(RecursiveDir)%(FileName)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="@(NativePdbs)">
+    <None Include="@(NativePdbs)" Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(AllowedReferenceRelatedFileExtensions)', '\.pdb'))">
       <Link>%(RecursiveDir)%(FileName)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
The reference pdb files are quite large and some users may want to exclude them from their build by altering the value of the `AllowedReferenceRelatedFileExtensions` property.

This PR adds a conditional to observe the users configuration.