### PR TITLE
Remove a redundant seek from the decompression example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,7 @@ public Byte[] Decode(Byte[] input)
     using (System.IO.MemoryStream msOutput = new System.IO.MemoryStream())
     {
         bs.CopyTo(msOutput);
-        msOutput.Seek(0, System.IO.SeekOrigin.Begin);
-        output = msOutput.ToArray();
-        return output;
+        return msOutput.ToArray();
     }
 }
 ```


### PR DESCRIPTION
According to the docs, [CopyTo](https://docs.microsoft.com/en-us/dotnet/api/system.io.stream.copyto) does not reset the position in the destination stream.
Also, the default position in a new stream is [set to zero](https://docs.microsoft.com/en-us/dotnet/api/system.io.memorystream?view=net-5.0#remarks). 

So we're good without doing any additional seeks.